### PR TITLE
[DEV] Meter Util 요금연산 GPS 연동

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -46,7 +46,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdkVersion flutter.minSdkVersion
-        targetSdkVersion flutter.targetSdkVersion
+        targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
     <queries>
         <intent>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.9.0'
     repositories {
         google()
         mavenCentral()

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -22,8 +24,22 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>https</string>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>This app needs access to location when using meter function.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>This app needs access to location when using meter function.</string>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>location</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -41,13 +57,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
-	<key>LSApplicationQueriesSchemes</key>
-    <array>
-        <string>https</string>
-    </array>
 </dict>
 </plist>

--- a/lib/pages/meter_page.dart
+++ b/lib/pages/meter_page.dart
@@ -335,7 +335,7 @@ class _MeterInfoState extends State<MeterInfo> {
                       meterInfoText(meterStatus),
                       Container(height: 10.0),
                       meterInfoText("주행 거리"),
-                      meterInfoText("${NumberFormat("#,##0.0").format(widget.meterUtil.meterSumDistance)}km")
+                      meterInfoText("${NumberFormat("#,##0.0").format(widget.meterUtil.meterSumDistance / 1000)}km")
                     ],
                   ),
                 ),

--- a/lib/pages/meter_page.dart
+++ b/lib/pages/meter_page.dart
@@ -25,6 +25,12 @@ class _MeterPageState extends State<MeterPage> {
   }
 
   @override
+  void dispose() {
+    super.dispose();
+    meterUtil?.stopMeter();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: MeterColor.meterBackground,

--- a/lib/pages/meter_page.dart
+++ b/lib/pages/meter_page.dart
@@ -12,7 +12,7 @@ class MeterPage extends StatefulWidget {
 }
 
 class _MeterPageState extends State<MeterPage> {
-  var meterUtil = MeterUtil();
+  MeterUtil? meterUtil;
 
   void updateMeterView() {
     setState(() {});
@@ -21,12 +21,7 @@ class _MeterPageState extends State<MeterPage> {
   @override
   void initState() {
     super.initState();
-
-    if(meterUtil.meterStatus == MeterStatus.METER_NOT_RUNNING) {
-      meterUtil.initMeter().then((_) => updateMeterView());
-    } else {
-      updateMeterView();
-    }
+    meterUtil = MeterUtil(updateView: updateMeterView);
   }
 
   @override
@@ -38,10 +33,10 @@ class _MeterPageState extends State<MeterPage> {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
-            MeterAnimation(meterUtil: meterUtil),
-            MeterCostView(meterUtil: meterUtil),
-            MeterInfo(meterUtil: meterUtil),
-            MeterControl(meterUtil: meterUtil, updateCallback: updateMeterView),
+            MeterAnimation(meterUtil: meterUtil!),
+            MeterCostView(meterUtil: meterUtil!),
+            MeterInfo(meterUtil: meterUtil!),
+            MeterControl(meterUtil: meterUtil!, updateCallback: updateMeterView),
           ],
         )
       )

--- a/lib/pages/meter_page.dart
+++ b/lib/pages/meter_page.dart
@@ -63,7 +63,8 @@ class _MeterAnimationState extends State<MeterAnimation> with SingleTickerProvid
   MeterTheme _curMeterTheme = MeterTheme.METER_THEME_HORSE;
 
   AnimationController? _meterAnimationController;
-  List<Image> _meterAnimationFrameList = [];
+  final List<Image> _meterCircleFrames = List.generate(8, (index) => Image.asset("assets/images/meter_circle/ic_circle_${index + 1}.png"));
+  final List<Image> _meterHorseFrames = List.generate(3, (index) => Image.asset("assets/images/meter_horse/ic_horse_${index + 1}.png"));
 
   @override
   void initState() {
@@ -76,8 +77,6 @@ class _MeterAnimationState extends State<MeterAnimation> with SingleTickerProvid
     PreferenceUtil().getPrefsValueS("pref_theme").then((res) => {
       setState(() {
         _curMeterTheme = res == "horse" ? MeterTheme.METER_THEME_HORSE : MeterTheme.METER_THEME_CIRCLE;
-        _loadImages();
-        _meterAnimationController!.repeat();
       })
     });
   }
@@ -98,52 +97,46 @@ class _MeterAnimationState extends State<MeterAnimation> with SingleTickerProvid
         child: AnimatedBuilder(
           animation: _meterAnimationController!,
           builder: (context, child) {
-            return _meterAnimationFrameList.isNotEmpty
-                ? _meterAnimationFrameList[(_meterAnimationController!.value * _meterAnimationFrameList.length).floor() % _meterAnimationFrameList.length]
-                : Container();
+            _updateDuration();
+
+            if(_curMeterTheme == MeterTheme.METER_THEME_CIRCLE) {
+              return _meterCircleFrames[(_meterAnimationController!.value * 8).floor() % 8];
+            } else {
+              return _meterHorseFrames[(_meterAnimationController!.value * 3).floor() % 3];
+            }
           }
         )
       ),
     );
   }
 
-  void _loadImages() {
+  void _updateDuration() {
+    _meterAnimationController!.repeat();
     if(_curMeterTheme == MeterTheme.METER_THEME_CIRCLE) {
       if(widget.meterUtil.meterCurSpeed > 50) {
-        _meterAnimationFrameList = List.generate(8, (index) => Image.asset("assets/images/meter_circle/ic_circle_${index + 1}.png"));
         _meterAnimationController!.duration = const Duration(milliseconds: 104);
       } else if(widget.meterUtil.meterCurSpeed > 30) {
-        _meterAnimationFrameList = List.generate(8, (index) => Image.asset("assets/images/meter_circle/ic_circle_${index + 1}.png"));
         _meterAnimationController!.duration = const Duration(milliseconds: 160);
       } else if(widget.meterUtil.meterCurSpeed > 15) {
-        _meterAnimationFrameList = List.generate(8, (index) => Image.asset("assets/images/meter_circle/ic_circle_${index + 1}.png"));
         _meterAnimationController!.duration = const Duration(milliseconds: 328);
       } else if(widget.meterUtil.meterCurSpeed > 0) {
-        _meterAnimationFrameList = List.generate(8, (index) => Image.asset("assets/images/meter_circle/ic_circle_${index + 1}.png"));
         _meterAnimationController!.duration = const Duration(milliseconds: 1000);
       } else {
-        _meterAnimationFrameList = [Image.asset("assets/images/meter_circle/ic_circle_1.png")];
-        _meterAnimationController!.duration = const Duration(milliseconds: 1000);
+        _meterAnimationController!.stop();
       }
     } else if(_curMeterTheme == MeterTheme.METER_THEME_HORSE) {
       if(widget.meterUtil.meterCurSpeed > 50) {
-        _meterAnimationFrameList = List.generate(3, (index) => Image.asset("assets/images/meter_horse/ic_horse_${index + 1}.png"));
         _meterAnimationController!.duration = const Duration(milliseconds: 142);
       } else if(widget.meterUtil.meterCurSpeed > 30) {
-        _meterAnimationFrameList = List.generate(3, (index) => Image.asset("assets/images/meter_horse/ic_horse_${index + 1}.png"));
         _meterAnimationController!.duration = const Duration(milliseconds: 200);
       } else if(widget.meterUtil.meterCurSpeed > 20) {
-        _meterAnimationFrameList = List.generate(3, (index) => Image.asset("assets/images/meter_horse/ic_horse_${index + 1}.png"));
         _meterAnimationController!.duration = const Duration(milliseconds: 250);
       } else if(widget.meterUtil.meterCurSpeed > 10) {
-        _meterAnimationFrameList = List.generate(3, (index) => Image.asset("assets/images/meter_horse/ic_horse_${index + 1}.png"));
         _meterAnimationController!.duration = const Duration(milliseconds: 333);
       } else if(widget.meterUtil.meterCurSpeed > 0) {
-        _meterAnimationFrameList = List.generate(3, (index) => Image.asset("assets/images/meter_horse/ic_horse_${index + 1}.png"));
         _meterAnimationController!.duration = const Duration(milliseconds: 500);
       } else {
-        _meterAnimationFrameList = [Image.asset("assets/images/meter_horse/ic_horse_1.png")];
-        _meterAnimationController!.duration = const Duration(milliseconds: 1000);
+        _meterAnimationController!.stop();
       }
     }
   }

--- a/lib/utils/meter_util.dart
+++ b/lib/utils/meter_util.dart
@@ -74,8 +74,8 @@ class MeterUtil {
     meterCurSpeed = curSpeed * 3.6;
     meterStatus = MeterStatus.METER_RUNNING;
 
-    meterCostCounter -= (meterCurSpeed * deltaTime).toInt();
-    meterSumDistance += meterCurSpeed * deltaTime;
+    meterCostCounter -= (curSpeed * deltaTime).toInt();
+    meterSumDistance += curSpeed * deltaTime;
 
     if(meterCurSpeed < 15) {
       meterCostCounter -= (prefCostRunPer / prefCostTimePer * deltaTime).toInt();

--- a/lib/utils/meter_util.dart
+++ b/lib/utils/meter_util.dart
@@ -1,12 +1,11 @@
 import 'package:taximeter/utils/preference_util.dart';
 
 class MeterUtil {
-  MeterUtil._privateConstructor();
-  static final MeterUtil _instance = MeterUtil._privateConstructor();
-
-  factory MeterUtil() {
-    return _instance;
+  MeterUtil({required this.updateView}) {
+    _initValue().then((res) => updateView());
   }
+
+  final Function updateView;
 
   var meterCost = 0;
   var meterCostCounter = 0;
@@ -32,12 +31,6 @@ class MeterUtil {
   var prefPercNightStart1 = 22;
   var prefPercNightStart2 = 23;
   var prefTheme = "horse";
-
-  Future<void> initMeter() async {
-    if(meterStatus == MeterStatus.METER_NOT_RUNNING) {
-      await _initValue();
-    }
-  }
 
   void startMeter() {
     if(meterStatus == MeterStatus.METER_NOT_RUNNING) {

--- a/lib/utils/meter_util.dart
+++ b/lib/utils/meter_util.dart
@@ -118,8 +118,19 @@ class MeterUtil {
   }
 
   void setPercNight(bool isEnabled) {
-    if(meterIsPercNight != isEnabled) {
-      meterIsPercNight = isEnabled;
+    int curH = int.parse(DateFormat('HH').format(DateTime.now()));
+    int premiumCost = 0;
+
+    if((curH >= 20 && curH >= prefPercNightStart1) || (curH <= 5 && curH < prefPercNightEnd1)) {
+      premiumCost = (curH >= 20 && curH >= prefPercNightStart2) || (curH <= 5 && curH < prefPercNightEnd2)
+          ? prefCostBase * prefPercNight2 ~/ 100
+          : prefCostBase * prefPercNight1 ~/ 100;
+    }
+
+    if(isEnabled) {
+      meterCost += premiumCost;
+    } else {
+      meterCost -= premiumCost;
     }
   }
 

--- a/lib/utils/meter_util.dart
+++ b/lib/utils/meter_util.dart
@@ -41,6 +41,7 @@ class MeterUtil {
 
   void startMeter() {
     if(meterStatus == MeterStatus.METER_NOT_RUNNING) {
+      increaseCost(0);
       _gpsTimer = Timer.periodic(
         const Duration(seconds: 1), (_) {
           Geolocator.getCurrentPosition(desiredAccuracy: LocationAccuracy.high)

--- a/lib/utils/meter_util.dart
+++ b/lib/utils/meter_util.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:taximeter/utils/preference_util.dart';
 
 class MeterUtil {
@@ -32,14 +34,25 @@ class MeterUtil {
   var prefPercNightStart2 = 23;
   var prefTheme = "horse";
 
+  late Timer _gpsTimer;
+
   void startMeter() {
     if(meterStatus == MeterStatus.METER_NOT_RUNNING) {
+      _gpsTimer = Timer.periodic(
+        const Duration(seconds: 1),
+        (_) {
+          increaseCost();
+        }
+      );
+
       meterStatus = MeterStatus.METER_RUNNING;
     }
   }
 
   void stopMeter() {
     if(meterStatus != MeterStatus.METER_NOT_RUNNING) {
+      _gpsTimer.cancel();
+
       meterCostMode = CostMode.COST_BASE;
       meterStatus = MeterStatus.METER_NOT_RUNNING;
     }

--- a/lib/utils/meter_util.dart
+++ b/lib/utils/meter_util.dart
@@ -112,8 +112,10 @@ class MeterUtil {
   }
 
   void setPercCity(bool isEnabled) {
-    if(meterIsPercCity != isEnabled) {
-      meterIsPercCity = isEnabled;
+    if(isEnabled) {
+      meterCost += prefCostBase * prefPercCity ~/ 100;
+    } else {
+      meterCost -= prefCostBase * prefPercCity ~/ 100;
     }
   }
 

--- a/lib/utils/meter_util.dart
+++ b/lib/utils/meter_util.dart
@@ -41,7 +41,9 @@ class MeterUtil {
 
   void startMeter() {
     if(meterStatus == MeterStatus.METER_NOT_RUNNING) {
+      meterStatus = MeterStatus.METER_GPS_ERROR;
       increaseCost(0);
+
       _gpsTimer = Timer.periodic(
         const Duration(seconds: 1), (_) {
           Geolocator.getCurrentPosition(desiredAccuracy: LocationAccuracy.high)

--- a/lib/utils/meter_util.dart
+++ b/lib/utils/meter_util.dart
@@ -42,13 +42,11 @@ class MeterUtil {
   void startMeter() {
     if(meterStatus == MeterStatus.METER_NOT_RUNNING) {
       _gpsTimer = Timer.periodic(
-        const Duration(seconds: 1),
-        (_) {
+        const Duration(seconds: 1), (_) {
           Geolocator.getCurrentPosition(
             desiredAccuracy: LocationAccuracy.high
-          ).then((pos) => (){
-            print(pos.speed);
-            increaseCost(pos.speed);
+          ).then((pos) => {
+            increaseCost(pos.speed)
           });
         }
       );

--- a/lib/utils/meter_util.dart
+++ b/lib/utils/meter_util.dart
@@ -21,7 +21,6 @@ class MeterUtil {
 
   var meterCostMode = CostMode.COST_BASE;
   var meterStatus = MeterStatus.METER_NOT_RUNNING;
-  var meterTheme = MeterTheme.METER_THEME_HORSE;
 
   var prefCostBase = 4800;
   var prefCostRunPer = 132;
@@ -34,7 +33,6 @@ class MeterUtil {
   var prefPercNightEnd2 = 2;
   var prefPercNightStart1 = 22;
   var prefPercNightStart2 = 23;
-  var prefTheme = "horse";
 
   late Timer _gpsTimer;
   int lastUpdateTime = 0;
@@ -137,7 +135,6 @@ class MeterUtil {
     prefPercNightEnd2 = await PreferenceUtil().getPrefsValueI("pref_perc_night_end_2") ?? 2;
     prefPercNightStart1 = await PreferenceUtil().getPrefsValueI("pref_perc_night_start_1") ?? 22;
     prefPercNightStart2 = await PreferenceUtil().getPrefsValueI("pref_perc_night_start_2") ?? 23;
-    prefTheme = await PreferenceUtil().getPrefsValueS("pref_theme") ?? "horse";
 
     meterCost = prefCostBase;
     meterCostCounter = prefDistBase;
@@ -149,7 +146,6 @@ class MeterUtil {
 
     meterCostMode = CostMode.COST_BASE;
     meterStatus = MeterStatus.METER_NOT_RUNNING;
-    meterTheme = prefTheme == "horse" ? MeterTheme.METER_THEME_HORSE : MeterTheme.METER_THEME_CIRCLE;
   }
 }
 

--- a/lib/utils/meter_util.dart
+++ b/lib/utils/meter_util.dart
@@ -71,13 +71,13 @@ class MeterUtil {
     final deltaTime = (curTime - lastUpdateTime) / 1000.0;
     lastUpdateTime = curTime;
 
-    meterCurSpeed = curSpeed.toDouble();
+    meterCurSpeed = curSpeed * 3.6;
     meterStatus = MeterStatus.METER_RUNNING;
 
     meterCostCounter -= (meterCurSpeed * deltaTime).toInt();
     meterSumDistance += meterCurSpeed * deltaTime;
 
-    if(meterCurSpeed < 4.2) {
+    if(meterCurSpeed < 15) {
       meterCostCounter -= (prefCostRunPer / prefCostTimePer * deltaTime).toInt();
 
       if(meterCostMode == CostMode.COST_DISTANCE) {

--- a/lib/utils/meter_util.dart
+++ b/lib/utils/meter_util.dart
@@ -91,7 +91,7 @@ class MeterUtil {
 
     if(meterCostCounter <= 0) {
       meterCost += 100;
-      meterCostCounter = prefCostRunPer;
+      meterCostCounter += prefCostRunPer;
 
       if(meterIsPercNight) {
         final curH = int.parse(DateFormat('HH').format(DateTime.now()));

--- a/lib/utils/meter_util.dart
+++ b/lib/utils/meter_util.dart
@@ -58,9 +58,7 @@ class MeterUtil {
   void stopMeter() {
     if(meterStatus != MeterStatus.METER_NOT_RUNNING) {
       _gpsTimer.cancel();
-
-      meterCostMode = CostMode.COST_BASE;
-      meterStatus = MeterStatus.METER_NOT_RUNNING;
+      _initValue();
     }
   }
 
@@ -143,10 +141,15 @@ class MeterUtil {
 
     meterCost = prefCostBase;
     meterCostCounter = prefDistBase;
-    meterCostMode = CostMode.COST_BASE;
     meterCurSpeed = 0.0;
-    meterTheme = prefTheme == "horse" ? MeterTheme.METER_THEME_HORSE : MeterTheme.METER_THEME_CIRCLE;
     meterSumDistance = 0.0;
+
+    meterIsPercCity = false;
+    meterIsPercNight = false;
+
+    meterCostMode = CostMode.COST_BASE;
+    meterStatus = MeterStatus.METER_NOT_RUNNING;
+    meterTheme = prefTheme == "horse" ? MeterTheme.METER_THEME_HORSE : MeterTheme.METER_THEME_CIRCLE;
   }
 }
 

--- a/lib/utils/meter_util.dart
+++ b/lib/utils/meter_util.dart
@@ -43,11 +43,8 @@ class MeterUtil {
     if(meterStatus == MeterStatus.METER_NOT_RUNNING) {
       _gpsTimer = Timer.periodic(
         const Duration(seconds: 1), (_) {
-          Geolocator.getCurrentPosition(
-            desiredAccuracy: LocationAccuracy.high
-          ).then((pos) => {
-            increaseCost(pos.speed)
-          });
+          Geolocator.getCurrentPosition(desiredAccuracy: LocationAccuracy.high)
+            .then((pos) => increaseCost(pos.speed));
         }
       );
 

--- a/lib/utils/meter_util.dart
+++ b/lib/utils/meter_util.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:geolocator/geolocator.dart';
 import 'package:intl/intl.dart';
 import 'package:taximeter/utils/preference_util.dart';
 
@@ -43,7 +44,12 @@ class MeterUtil {
       _gpsTimer = Timer.periodic(
         const Duration(seconds: 1),
         (_) {
-          increaseCost(0);
+          Geolocator.getCurrentPosition(
+            desiredAccuracy: LocationAccuracy.high
+          ).then((pos) => (){
+            print(pos.speed);
+            increaseCost(pos.speed);
+          });
         }
       );
 
@@ -60,7 +66,7 @@ class MeterUtil {
     }
   }
 
-  void increaseCost(int curSpeed) {
+  void increaseCost(double curSpeed) {
     final curTime = DateTime.now().millisecondsSinceEpoch;
     if(lastUpdateTime == 0) {
       lastUpdateTime = curTime;
@@ -107,6 +113,8 @@ class MeterUtil {
         meterCostMode = CostMode.COST_DISTANCE;
       }
     }
+
+    updateView();
   }
 
   void setPercCity(bool isEnabled) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   firebase_analytics: ^11.2.0
   firebase_crashlytics: ^4.0.3
   intl: ^0.19.0
+  geolocator: ^12.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
Meter Util의 요금연산 로직을 구성하고, GPS와 연동하였습니다.

## Description
- Meter Util에 요금연산 로직을 구성하였습니다. 기존 [Android Repo](https://github.com/yymin1022/TaxiMeter)의 로직을 포팅하였습니다.
- Geolocator 패키지에 기반해, 운행 중에 매 1초마다 속도를 받아와, 이를 기반으로 요금 연산을 수행합니다.
- 별도로 Service는 구성하지 않고, 임시 백그라운드의 동작만이 보장되도록 하였습니다.