### PR TITLE
[FIX] 위치정보 권한 요청 Flow 관련 수정

### DIFF
--- a/lib/pages/welcome_page.dart
+++ b/lib/pages/welcome_page.dart
@@ -157,7 +157,7 @@ class WelcomePagePermission extends StatefulWidget {
 }
 
 class _WelcomePagePermissionState extends State<WelcomePagePermission> {
-  bool isGranted = false;
+  bool isTriedGrant = false;
 
   @override
   Widget build(BuildContext context) {
@@ -180,31 +180,11 @@ class _WelcomePagePermissionState extends State<WelcomePagePermission> {
           const SizedBox(height: 20.0),
           OutlinedButton(
             onPressed: () {
-              if(!isGranted) {
+              if(!isTriedGrant) {
                 requestPermissions().then(
                   (res) => setState(() {
-                    isGranted = res;
+                    isTriedGrant = true;
                   })
-                );
-              }
-            },
-            child: Text(
-              isGranted
-                ? AppLocalizations.of(context)!.welcome_permission_btn_done
-                : AppLocalizations.of(context)!.welcome_permission_btn,
-              style: TextStyle(
-                color: isGranted ? MeterColor.btnTextDisabled : MeterColor.btnTextEnabled
-              ),
-            ),
-          ),
-          OutlinedButton(
-            onPressed: () {
-              if(!isGranted) {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    content: Text(AppLocalizations.of(context)!.welcome_snack_permission_not_granted),
-                    duration: const Duration(seconds: 2),
-                  )
                 );
               } else {
                 widget.goNext();
@@ -212,8 +192,8 @@ class _WelcomePagePermissionState extends State<WelcomePagePermission> {
             },
             child: Text(
               AppLocalizations.of(context)!.welcome_btn_next,
-              style: TextStyle(
-                color: isGranted ? MeterColor.btnTextEnabled : MeterColor.btnTextDisabled
+              style: const TextStyle(
+                color: MeterColor.btnTextEnabled
               ),
             ),
           ),


### PR DESCRIPTION
## Summary
위치정보 권한을 요청하는 Flow를 수정하였습니다.

## Description
- Apple 앱스토어 심사 거절사항에 맞추어, `welcome_page` 내에서 위치정보 권한 요청 시, 별도의 버튼을 제거하고 `다음` 버튼으로 동작을 통일하였습니다.
- 기존에는 `위치권한 허용` 버튼과 `다음` 버튼이 별도로 나누어 존재하였으나, `다음`버튼으로 통합하였습니다.
- 첫번째 클릭 시, 위치정보 관련 다이얼로그가 전시되며, 권한을 허용하거나 허용하지 않은 이후, 다시 버튼을 클릭하면 다음 페이지로 이동합니다.